### PR TITLE
Added Polish language

### DIFF
--- a/src/js/translations.js
+++ b/src/js/translations.js
@@ -6,6 +6,7 @@ import sk from '../translations/sk.json';
 import ru from '../translations/ru.json';
 import ro from '../translations/ro.json';
 import fr from '../translations/fr.json';
+import pl from '../translations/pl.json';
 
 const languageMap = {
   fi,
@@ -16,6 +17,7 @@ const languageMap = {
   ru,
   ro,
   fr,
+  pl,
 };
 
 export const languages = {
@@ -27,6 +29,7 @@ export const languages = {
   'ru': 'Русский (Russian)',
   'ro': 'Română (Romanian)',
   'fr': 'Français (French)',
+  'pl': 'Polski (Polish)',
 };
 
 const languageSelector = document.getElementById('language-selector');

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -1,0 +1,21 @@
+{
+  "error-occured": "B³¹d uniemo¿liwi³ poprawne dzia³anie rozszerzenia: ",
+  "version-update-message": "U¿ywasz teraz ezpp! w wersji v{0}",
+  "changelog": "dziennik zmian",
+  "accuracy": "Celnoœæ",
+  "combo": "Combo",
+  "empty-fc": "(puste = FC)",
+  "misses": "Missy",
+  "mod-hidden": "Hidden",
+  "mod-hardrock": "HardRock",
+  "mod-doubletime": "DoubleTime",
+  "mod-flashlight": "Flashlight",
+  "mod-nofail": "NoFail",
+  "mod-easy": "Easy",
+  "mod-halftime": "HalfTime",
+  "mod-spunout": "SpunOut",
+  "language": "Jêzyk",
+  "settings": "Ustawienia",
+  "analytics": "Wyœlij anonimowe dane analityczne",
+  "result": "To oko³o {0}pp."
+}


### PR DESCRIPTION
Added support for Polish language.
Technically, "Misses" should've been translated to something like "Chybienia" or "Pudła", but people tend to refer to misses as "missy" in Polish, so I think the translation is much better like this.