### PR TITLE
pp calculation for taiko without HR, DT, EZ, HT support

### DIFF
--- a/background/content.js
+++ b/background/content.js
@@ -6,32 +6,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const [, beatmapId] = activeTabHref.match(/\/b\/(\d+)/i) || [];
       const [, beatmapSetId] = graphImageSrc.match(/=(\d+)$/i) || [];
       const stars = parseFloat(document.querySelectorAll("th[class~=beatmap-stats-table__label]")[2].parentElement.children.item(2).textContent, 10); // TODO: replace hacky way with accurate star rating calculator
+      // cleanBeatmap.ncircles seemed wrong, so we get circle count from here. again, this is hacky way so it needs to be replaced in the future
+      const ncircles = parseInt((document.querySelector("div[data-orig-title='Circle Count']") || document.querySelector("div[title='Circle Count']")).children.item(1).textContent.replace(',', ''), 10);
       sendResponse({
         status: 'SUCCESS',
         beatmapId,
         beatmapSetId,
-        stars,
-      });
-    } catch (error) {
-      sendResponse({
-        status: 'ERROR',
-        error: {
-          message: error.message,
-          arguments: error.arguments,
-          type: error.type,
-          name: error.name,
-          stack: error.stack,
-        },
-      });
-    }
-  }
-  if (request.action === 'GET_BEATMAP_STARS') {
-    try {
-      const stars = parseFloat(document.querySelectorAll('th[class~=beatmap-stats-table__label]')[2].parentElement.children.item(2).textContent, 10);
-      // cleanBeatmap.ncircles seems wrong, so we get circle count from here. again, this is hacky way so it needs to be replaced in the future
-      const ncircles = parseInt((document.querySelector("div[data-orig-title='Circle Count']") || document.querySelector("div[title='Circle Count']")).children.item(1).textContent.replace(',', ''), 10);
-      sendResponse({
-        status: 'SUCCESS',
         stars,
         ncircles,
       });

--- a/background/content.js
+++ b/background/content.js
@@ -5,9 +5,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const graphImageSrc = document.querySelector('img[src^="/pages/include/beatmap-rating-graph.php"]').getAttribute('src');
       const [, beatmapId] = activeTabHref.match(/\/b\/(\d+)/i) || [];
       const [, beatmapSetId] = graphImageSrc.match(/=(\d+)$/i) || [];
-      const stars = parseFloat(document.querySelectorAll("th[class~=beatmap-stats-table__label]")[2].parentElement.children.item(2).textContent, 10); // TODO: replace hacky way with accurate star rating calculator
-      // cleanBeatmap.ncircles seemed wrong, so we get circle count from here. again, this is hacky way so it needs to be replaced in the future
-      const ncircles = parseInt((document.querySelector("div[data-orig-title='Circle Count']") || document.querySelector("div[title='Circle Count']")).children.item(1).textContent.replace(',', ''), 10);
       sendResponse({
         status: 'SUCCESS',
         beatmapId,
@@ -28,4 +25,26 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       });
     }
   }
+  if (request.action === 'GET_BEATMAP_STATS') {
+    try {
+      const stars = parseFloat(document.querySelectorAll("th[class~=beatmap-stats-table__label]")[2].parentElement.children.item(2).textContent, 10); // TODO: replace hacky way with accurate star rating calculator
+      // cleanBeatmap.ncircles seemed wrong, so we get circle count from here. again, this is hacky way so it needs to be replaced in the future
+      const ncircles = parseInt((document.querySelector("div[data-orig-title='Circle Count']") || document.querySelector("div[title='Circle Count']")).children.item(1).textContent.replace(',', ''), 10);
+      sendResponse({
+        status: 'SUCCESS',
+        stars,
+        ncircles,
+      });
+    } catch (error) {
+      sendResponse({
+        status: 'ERROR',
+        error: {
+          message: error.message,
+          arguments: error.arguments,
+          type: error.type,
+          name: error.name,
+          stack: error.stack,
+        },
+      });
+    }  }
 });

--- a/background/content.js
+++ b/background/content.js
@@ -5,10 +5,35 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const graphImageSrc = document.querySelector('img[src^="/pages/include/beatmap-rating-graph.php"]').getAttribute('src');
       const [, beatmapId] = activeTabHref.match(/\/b\/(\d+)/i) || [];
       const [, beatmapSetId] = graphImageSrc.match(/=(\d+)$/i) || [];
+      const stars = parseFloat(document.querySelectorAll("th[class~=beatmap-stats-table__label]")[2].parentElement.children.item(2).textContent, 10); // TODO: replace hacky way with accurate star rating calculator
       sendResponse({
         status: 'SUCCESS',
         beatmapId,
         beatmapSetId,
+        stars,
+      });
+    } catch (error) {
+      sendResponse({
+        status: 'ERROR',
+        error: {
+          message: error.message,
+          arguments: error.arguments,
+          type: error.type,
+          name: error.name,
+          stack: error.stack,
+        },
+      });
+    }
+  }
+  if (request.action === 'GET_BEATMAP_STARS') {
+    try {
+      const stars = parseFloat(document.querySelectorAll('th[class~=beatmap-stats-table__label]')[2].parentElement.children.item(2).textContent, 10);
+      // cleanBeatmap.ncircles seems wrong, so we get circle count from here. again, this is hacky way so it needs to be replaced in the future
+      const ncircles = parseInt((document.querySelector("div[data-orig-title='Circle Count']") || document.querySelector("div[title='Circle Count']")).children.item(1).textContent.replace(',', ''), 10);
+      sendResponse({
+        status: 'SUCCESS',
+        stars,
+        ncircles,
       });
     } catch (error) {
       sendResponse({

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,3 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 
-export const BEATMAP_URL_REGEX = /^https?:\/\/(osu|new).ppy.sh\/([bs]|beatmapsets)\/(\d+)\/?(#osu\/\d+)?/i;
+export const BEATMAP_URL_REGEX = /^https?:\/\/(osu|new).ppy.sh\/([bs]|beatmapsets)\/(\d+)\/?(#(osu|taiko|fruits|mania)\/(\d+))?/i;

--- a/popup/calculators/taiko.js
+++ b/popup/calculators/taiko.js
@@ -1,43 +1,37 @@
 import ojsama from 'ojsama';
 
-export const GREAT_MIN = 34;
-export const GREAT_MID = 49;
-export const GREAT_MAX = 64;
+export const GREAT_MIN = 50;
+export const GREAT_MID = 35;
+export const GREAT_MAX = 20;
 
-export function difficltyRange(od, min, mid, max) {
-  if (od > 5) return mid + (max - mid) * (od - 5) / 5;
-  if (od < 5) return mid - (mid - min) * (5 - od) / 5;
+export function difficltyRange(difficulty, min, mid, max) {
+  if (difficulty > 5) return mid + (max - mid) * (difficulty - 5) / 5;
+  if (difficulty < 5) return mid - (mid - min) * (5 - difficulty) / 5;
   return mid;
 }
 
-// it should work on most maps, but there are some issues that needs to be resolved:
-// - https://osu.ppy.sh/beatmapsets/554873#taiko/1174566 (giving too much huge pp)
-// - https://osu.ppy.sh/beatmapsets/1057894#taiko/2216559 (giving a bit more pp)
-// - https://osu.ppy.sh/beatmapsets/1236758#taiko/2570727 (giving less pp, but only few)
-// - https://osu.ppy.sh/beatmapsets/328117#taiko/727903 (giving a bit more pp)
-// - https://osu.ppy.sh/beatmapsets/1225464#taiko/2548643 (giving less pp)
-// - https://osu.ppy.sh/beatmapsets/967870#taiko/2025380 (giving more pp)
+// javascript implementation of osu!lazer's pp calculator implementation: https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
 /**
  * @param {ojsama.beatmap} map
  * @param {{ total: number }} stars
  * @param {ojsama.modbits} mods
  */
 export function calculateTaikoPerformance(map, stars, mods, combo, misses, accuracy) {
-  let multiplier = 1.3;
+  let multiplier = 1.1;
   if (mods & ojsama.modbits.nf) multiplier *= 0.90;
   if (mods & ojsama.modbits.hd) multiplier *= 1.10;
   const strainValue = calculateTaikoStrainPerformance(stars, mods, misses, accuracy / 100, combo);
-  const accuracyValue = calculateTaikoAccuracyPerformance((Math.floor(difficltyRange(map.od, GREAT_MIN, GREAT_MID, GREAT_MAX)) / map.tick_rate), accuracy / 100, combo);
+  const accuracyValue = calculateTaikoAccuracyPerformance((difficltyRange(map.od, GREAT_MIN, GREAT_MID, GREAT_MAX) | 0), accuracy / 100, combo); // todo: clockRate, see DifficultyCalculator.cs:47, TaikoDifficultyCalculator.cs:65
   const total = Math.pow(
     Math.pow(strainValue, 1.1) + Math.pow(accuracyValue, 1.1),
     1.0 / 1.1
   ) * multiplier;
-  return { total };
+  return { total, strain: strainValue, accuracy: accuracyValue };
 }
 
 export function calculateTaikoStrainPerformance(stars, mods, misses, accuracy, combo) {
   let strainValue = Math.pow(5.0 * Math.max(1.0, stars / 0.0075) - 4.0, 2.0) / 100000.0;
-  const lengthBonus = 1 + 0.16 * Math.min(1.0, combo / 1500.0);
+  const lengthBonus = 1 + 0.1 * Math.min(1.0, combo / 1500.0);
   strainValue *= lengthBonus;
   strainValue *= Math.pow(0.985, misses);
   if (mods & ojsama.modbits.hd) strainValue *= 1.025;
@@ -46,6 +40,7 @@ export function calculateTaikoStrainPerformance(stars, mods, misses, accuracy, c
 }
 
 export function calculateTaikoAccuracyPerformance(greatHitWindow, accuracy, combo) {
+  if (greatHitWindow <= 0) return 0;
   const accValue = Math.pow(150.0 / greatHitWindow, 1.1) * Math.pow(accuracy, 15) * 22.0;
   return accValue * Math.min(1.15, Math.pow(combo / 1500.0, 0.3));
 }

--- a/popup/calculators/taiko.js
+++ b/popup/calculators/taiko.js
@@ -1,0 +1,51 @@
+import ojsama from 'ojsama';
+
+export const GREAT_MIN = 34;
+export const GREAT_MID = 49;
+export const GREAT_MAX = 64;
+
+export function difficltyRange(od, min, mid, max) {
+  if (od > 5) return mid + (max - mid) * (od - 5) / 5;
+  if (od < 5) return mid - (mid - min) * (5 - od) / 5;
+  return mid;
+}
+
+// it should work on most maps, but there are some issues that needs to be resolved:
+// - https://osu.ppy.sh/beatmapsets/554873#taiko/1174566 (giving too much huge pp)
+// - https://osu.ppy.sh/beatmapsets/1057894#taiko/2216559 (giving a bit more pp)
+// - https://osu.ppy.sh/beatmapsets/1236758#taiko/2570727 (giving less pp, but only few)
+// - https://osu.ppy.sh/beatmapsets/328117#taiko/727903 (giving a bit more pp)
+// - https://osu.ppy.sh/beatmapsets/1225464#taiko/2548643 (giving less pp)
+// - https://osu.ppy.sh/beatmapsets/967870#taiko/2025380 (giving more pp)
+/**
+ * @param {ojsama.beatmap} map
+ * @param {{ total: number }} stars
+ * @param {ojsama.modbits} mods
+ */
+export function calculateTaikoPerformance(map, stars, mods, combo, misses, accuracy) {
+  let multiplier = 1.3;
+  if (mods & ojsama.modbits.nf) multiplier *= 0.90;
+  if (mods & ojsama.modbits.hd) multiplier *= 1.10;
+  const strainValue = calculateTaikoStrainPerformance(stars, mods, misses, accuracy / 100, combo);
+  const accuracyValue = calculateTaikoAccuracyPerformance((Math.floor(difficltyRange(map.od, GREAT_MIN, GREAT_MID, GREAT_MAX)) / map.tick_rate), accuracy / 100, combo);
+  const total = Math.pow(
+    Math.pow(strainValue, 1.1) + Math.pow(accuracyValue, 1.1),
+    1.0 / 1.1
+  ) * multiplier;
+  return { total };
+}
+
+export function calculateTaikoStrainPerformance(stars, mods, misses, accuracy, combo) {
+  let strainValue = Math.pow(5.0 * Math.max(1.0, stars / 0.0075) - 4.0, 2.0) / 100000.0;
+  const lengthBonus = 1 + 0.16 * Math.min(1.0, combo / 1500.0);
+  strainValue *= lengthBonus;
+  strainValue *= Math.pow(0.985, misses);
+  if (mods & ojsama.modbits.hd) strainValue *= 1.025;
+  if (mods & ojsama.modbits.fl) strainValue *= 1.05 * lengthBonus;
+  return strainValue * accuracy;
+}
+
+export function calculateTaikoAccuracyPerformance(greatHitWindow, accuracy, combo) {
+  const accValue = Math.pow(150.0 / greatHitWindow, 1.1) * Math.pow(accuracy, 15) * 22.0;
+  return accValue * Math.min(1.15, Math.pow(combo / 1500.0, 0.3));
+}

--- a/popup/index.js
+++ b/popup/index.js
@@ -31,6 +31,8 @@ const resultElement = document.getElementById('result');
 const errorElement = document.getElementById('error');
 const bpmElement = document.getElementById('bpm');
 const arElement = document.getElementById('ar');
+const resultBoxElement = document.getElementById('result-box');
+const resultDetailsElement = document.getElementById('result-details');
 
 const setResultText = createTextSetter(resultElement, 'result');
 
@@ -221,7 +223,7 @@ function calculate() {
     const msPerBeat = cleanBeatmap.timing_points[0].ms_per_beat;
     const bpm = 1 / msPerBeat * 1000 * 60 * bpmMultiplier;
 
-    let stars;
+    let stars = { total: 0 };
     let pp;
     if (cleanBeatmap.mode === 0) {
       stars = new ojsama.diff().calc({ map: cleanBeatmap, mods: modifiers });
@@ -232,11 +234,14 @@ function calculate() {
         nmiss: misses,
         acc_percent: accuracy,
       });
+      resultDetailsElement.textContent = `Acc: ${Math.round(pp.acc * 10) / 10}, Aim: ${Math.round(pp.aim * 10) / 10}, Spd: ${Math.round(pp.speed * 10) / 10}`;
     }
     if (cleanBeatmap.mode === 1) {
+      // todo: implement star rating calculator
       stars = { total: pageInfo.stars };
       pp = calculateTaikoPerformance(cleanBeatmap, stars.total, modifiers, combo, misses, accuracy);
       arElement.parentElement.style.display = 'none';
+      resultDetailsElement.textContent = `Strain: ${Math.round(pp.strain * 10) / 10}, Accuracy: ${Math.round(pp.accuracy * 10) / 10}`;
       // disable these mods as they are not supported yet (missing star rating calculator)
       document.getElementById('mod-hr').disabled = true;
       document.getElementById('mod-dt').disabled = true;

--- a/popup/index.js
+++ b/popup/index.js
@@ -372,12 +372,14 @@ const getPageInfo = (url, tabId) => new Promise((resolve, reject) => {
   info.isOldSite = match[2] !== 'beatmapsets';
 
   if (!info.isOldSite) {
+    // match[5] contains gamemode: osu, taiko, fruits, mania
     const beatmapId = match[6];
 
     info.beatmapSetId = match[3];
     info.beatmapId = beatmapId;
 
     chrome.tabs.sendMessage(tabId, { action: 'GET_BEATMAP_STARS' }, (response) => {
+      if (!response) return reject(new Error('Empty response from content script')); // I don't know why but it happened to me (acrylic-style) multiple times
       if (response.status === 'ERROR') {
         reject(response.error);
       } else {

--- a/popup/index.js
+++ b/popup/index.js
@@ -378,7 +378,7 @@ const getPageInfo = (url, tabId) => new Promise((resolve, reject) => {
     info.beatmapSetId = match[3];
     info.beatmapId = beatmapId;
 
-    chrome.tabs.sendMessage(tabId, { action: 'GET_BEATMAP_STARS' }, (response) => {
+    chrome.tabs.sendMessage(tabId, { action: 'GET_BEATMAP_INFO' }, (response) => {
       if (!response) return reject(new Error('Empty response from content script')); // I don't know why but it happened to me (acrylic-style) multiple times
       if (response.status === 'ERROR') {
         reject(response.error);
@@ -396,10 +396,11 @@ const getPageInfo = (url, tabId) => new Promise((resolve, reject) => {
       if (response.status === 'ERROR') {
         reject(response.error);
       } else {
-        const { beatmapId, beatmapSetId, stars } = response;
+        const { beatmapId, beatmapSetId, stars, ncircles } = response;
         info.beatmapSetId = beatmapSetId;
         info.beatmapId = beatmapId;
         info.stars = stars;
+        info.ncircles = ncircles;
 
         resolve(info);
       }

--- a/popup/index.js
+++ b/popup/index.js
@@ -31,7 +31,6 @@ const resultElement = document.getElementById('result');
 const errorElement = document.getElementById('error');
 const bpmElement = document.getElementById('bpm');
 const arElement = document.getElementById('ar');
-const resultBoxElement = document.getElementById('result-box');
 const resultDetailsElement = document.getElementById('result-details');
 
 const setResultText = createTextSetter(resultElement, 'result');
@@ -234,7 +233,7 @@ function calculate() {
         nmiss: misses,
         acc_percent: accuracy,
       });
-      resultDetailsElement.textContent = `Acc: ${Math.round(pp.acc * 10) / 10}, Aim: ${Math.round(pp.aim * 10) / 10}, Spd: ${Math.round(pp.speed * 10) / 10}`;
+      resultDetailsElement.textContent = `Acc: ${Math.round(pp.acc * 10) / 10}, Aim: ${Math.round(pp.aim * 10) / 10}, Speed: ${Math.round(pp.speed * 10) / 10}`;
     }
     if (cleanBeatmap.mode === 1) {
       // todo: implement star rating calculator
@@ -242,22 +241,23 @@ function calculate() {
       pp = calculateTaikoPerformance(cleanBeatmap, stars.total, modifiers, combo, misses, accuracy);
       arElement.parentElement.style.display = 'none';
       resultDetailsElement.textContent = `Strain: ${Math.round(pp.strain * 10) / 10}, Accuracy: ${Math.round(pp.accuracy * 10) / 10}`;
+      // disable spin out mod as taiko does not have this
+      document.getElementById('mod-so').disabled = true;
+      document.getElementById('mod-so').value = false;
+      document.querySelector("label[for=mod-so]").style.display = 'none';
       // disable these mods as they are not supported yet (missing star rating calculator)
       document.getElementById('mod-hr').disabled = true;
       document.getElementById('mod-dt').disabled = true;
       document.getElementById('mod-ez').disabled = true;
       document.getElementById('mod-ht').disabled = true;
-      document.getElementById('mod-so').disabled = true;
       document.getElementById('mod-hr').value = false;
       document.getElementById('mod-dt').value = false;
       document.getElementById('mod-ez').value = false;
       document.getElementById('mod-ht').value = false;
-      document.getElementById('mod-so').value = false;
       document.querySelector("label[for=mod-hr]").style.display = 'none';
       document.querySelector("label[for=mod-dt]").style.display = 'none';
       document.querySelector("label[for=mod-ez]").style.display = 'none';
       document.querySelector("label[for=mod-ht]").style.display = 'none';
-      document.querySelector("label[for=mod-so]").style.display = 'none';
     }
 
     const { beatmapId } = pageInfo;

--- a/popup/styles/modules/_result.sass
+++ b/popup/styles/modules/_result.sass
@@ -2,8 +2,8 @@
   position: relative
   top: 0
   box-sizing: border-box
-  height: 3.8em
   padding-top: 0.5em
+  padding-bottom: 0.6em
   transition: 0.1s all ease-out
   overflow: hidden
   background-image: url('/assets/button-bg.svg')

--- a/popup/styles/modules/_result.sass
+++ b/popup/styles/modules/_result.sass
@@ -2,7 +2,7 @@
   position: relative
   top: 0
   box-sizing: border-box
-  height: 2.5em
+  height: 3.8em
   padding-top: 0.5em
   transition: 0.1s all ease-out
   overflow: hidden

--- a/static/popup.html
+++ b/static/popup.html
@@ -107,7 +107,10 @@
       </div>
     </div>
   </div>
-  <div class="result" id="result"></div>
+  <div class="result" id="result-box">
+    <p id="result"></p>
+    <p id="result-details"></p>
+  </div>
   <div class="settings" id="settings">
     <button id="close-settings">
       <i class="material-icons">clear</i>


### PR DESCRIPTION
This PR adds pp calculation for taiko.

Features
----
- taiko pp calculation (except for star rating changing mods)
  - reference: https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
- "pp details" (see below)
  - may not be needed. I used it mainly for debug but looked good so I made it a feature (I will remove it if it's unnecessary)
  - when on std
    ![image](https://user-images.githubusercontent.com/19150229/111975568-1ae22f80-8b44-11eb-90fb-b5c3d10919cf.png)
  - when on taiko
    ![image](https://user-images.githubusercontent.com/19150229/111975659-30575980-8b44-11eb-89fc-762d049fa5ea.png)

Important notes
----
- I didn't write the star rating calculator (it was very complex, at least for me.), it just grabs the star rating from the content script. (I might consider writing it if I wanted to)
- Thus, we cannot support HR, DT, EZ, HT (for now) since it requires a star rating calculator.
- taiko does not have the Spin-Out mod, so it is hidden.
- It supports std -> taiko conversion, but it gives the wrong max combos and pp.
- Might need to replace "combo" with "great", for an accurate result
