### PR TITLE
Fix Swedish translation encoding

### DIFF
--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1,8 +1,8 @@
 {
-  "error-occured": "Ett fel fˆrhindrade till‰gget att fungera: ",
-  "version-update-message": "Du anv‰nder nu ezpp! v{0}",
-  "changelog": "‰ndringshistorik",
-  "accuracy": "Tr‰ffs‰kerhet",
+  "error-occured": "Ett fel f√∂rhindrade till√§gget att fungera: ",
+  "version-update-message": "Du anv√§nder nu ezpp! v{0}",
+  "changelog": "√§ndringshistorik",
+  "accuracy": "Tr√§ffs√§kerhet",
   "combo": "Kombo",
   "empty-fc": "(tom = FC)",
   "misses": "Missar",
@@ -14,9 +14,9 @@
   "mod-easy": "Easy",
   "mod-halftime": "HalfTime",
   "mod-spunout": "SpunOut",
-  "language": "SprÂk",
-  "settings": "Inst‰llningar",
+  "language": "Spr√•k",
+  "settings": "Inst√§llningar",
   "analytics": "Skicka anonym data",
-  "result": "Det blir ungef‰r {0}pp.",
-  "darkmode": "S‰tt pÂ mˆrk tema"
+  "result": "Det blir ungef√§r {0}pp.",
+  "darkmode": "S√§tt p√• m√∂rk tema"
 }


### PR DESCRIPTION
Oops, should've tested before. I've done that now locally. Was ISO-8859-1 apparently or something. Translation is otherwise unchanged.

before:

![image](https://user-images.githubusercontent.com/36758269/112059621-5ab51100-8b5c-11eb-8bed-e2162814e15f.png)

after:

![image](https://user-images.githubusercontent.com/36758269/112059658-67396980-8b5c-11eb-93aa-0b38a07a1726.png)
