### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.ts text eol=lf


### PR DESCRIPTION
...to prevent happening this mess every time I checkout. (it's eslint complaining about having CRLF instead of LF)
![image](https://user-images.githubusercontent.com/19150229/112325059-b5827000-8cf6-11eb-9c08-d22d613707fd.png)
I'm using Windows and the git's auto CRLF feature is very annoying, so let's turn it off.
Maybe use `*.*` instead of `*.js` and `*.ts`?