### PR TITLE
Migrate to Manifest V3

### DIFF
--- a/background/background.ts
+++ b/background/background.ts
@@ -2,8 +2,8 @@ import { BEATMAP_URL_REGEX } from '../common/constants'
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.status === 'complete' && tab.url!.match(BEATMAP_URL_REGEX)) {
-    chrome.pageAction.show(tabId)
+    chrome.action.enable(tabId)
   } else if (!tab.url!.match(BEATMAP_URL_REGEX)) {
-    chrome.pageAction.hide(tabId)
+    chrome.action.disable(tabId)
   }
 })

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "ezpp!",
   "description": "Calculate pp for a beatmap directly in your browser.",
   "version": "1.10.2",
@@ -13,19 +13,20 @@
     }
   },
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "content_scripts": [{
     "matches": ["*://osu.ppy.sh/*"],
     "js": ["content.js"]
   }],
-  "page_action": {
+  "action": {
     "default_icon": "icon48.png",
     "default_popup": "popup.html"
   },
   "permissions": [
-    "tabs", "storage",
-    "https://*.ppy.sh/",
-    "http://*.ppy.sh/"
+    "tabs", "storage"
+  ],
+  "host_permissions": [
+    "*://*.ppy.sh/"
   ]
 }


### PR DESCRIPTION
Not a big update. Resolves #91.

manifest.json
- `manifest_version: 2` -> `manifest_version: 3`
- `background.scripts` -> `background.service_worker`
- `page_action` -> `action`
- site permissions moved to `host_permissions` (`*://*.ppy.sh/` is sufficient)

background.ts
- `chrome.pageAction.show` -> `chrome.action.enable`
- `chrome.pageAction.hide` -> `chrome.action.disable`