### PR TITLE
Revert "Migrate to Manifest V3"

### DIFF
--- a/background/background.ts
+++ b/background/background.ts
@@ -2,8 +2,8 @@ import { BEATMAP_URL_REGEX } from '../common/constants'
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.status === 'complete' && tab.url!.match(BEATMAP_URL_REGEX)) {
-    chrome.action.enable(tabId)
+    chrome.pageAction.show(tabId)
   } else if (!tab.url!.match(BEATMAP_URL_REGEX)) {
-    chrome.action.disable(tabId)
+    chrome.pageAction.hide(tabId)
   }
 })

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "ezpp!",
   "description": "Calculate pp for a beatmap directly in your browser.",
   "version": "1.10.2",
@@ -13,20 +13,19 @@
     }
   },
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "content_scripts": [{
     "matches": ["*://osu.ppy.sh/*"],
     "js": ["content.js"]
   }],
-  "action": {
+  "page_action": {
     "default_icon": "icon48.png",
     "default_popup": "popup.html"
   },
   "permissions": [
-    "tabs", "storage"
-  ],
-  "host_permissions": [
-    "*://*.ppy.sh/"
+    "tabs", "storage",
+    "https://*.ppy.sh/",
+    "http://*.ppy.sh/"
   ]
 }


### PR DESCRIPTION
Reverts oamaok/ezpp#111

We need to revert this since *all* browsers except chrome don't support manifest version 3.

Or another option (not included in this PR): Chrome uses manifest v3, but Firefox uses manifest v2.

Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version

poor cross-browser compatibility :(
(note: edge actually supports v3 now)
![image](https://user-images.githubusercontent.com/19150229/121767875-08512280-cb96-11eb-831a-7d1d3b667e85.png)