### PR TITLE
fixed displaying 'NaNpp' in some cases

### DIFF
--- a/popup/index.ts
+++ b/popup/index.ts
@@ -272,8 +272,9 @@ const calculate = () => {
 
     difficultyStarsElement.innerText = stars.total.toFixed(2)
     bpmElement.innerText = (Math.round(bpm * 10) / 10).toString()
-
-    setResultText(Math.round(pp.total))
+    
+    let total_pp = Math.round(pp.total)
+    setResultText(Number.isNaN(total_pp) ? 0 : total_pp)
   } catch (error) {
     displayError(error)
   }


### PR DESCRIPTION
When there is nothing in the accuracy input, pp calculation displays as "NaNpp".

![image](https://user-images.githubusercontent.com/39219491/122244585-ab26db00-cecd-11eb-8b6c-217e9dd4dbe5.png)

Now when pp.total is NaN its converts to 0

 