### PR TITLE
fixed displaying 'NaNpp' in some cases

### DIFF
--- a/popup/index.ts
+++ b/popup/index.ts
@@ -104,7 +104,7 @@ const getCalculationSettings = () => {
   const maxCombo = getMaxCombo()
 
   const accuracy = Mth.clamp(
-    parseFloat(accuracyElement.value.replace(',', '.')),
+    parseFloat((accuracyElement.value || '0').replace(',', '.')),
     0,
     100
   )


### PR DESCRIPTION
When there is nothing in the accuracy input, pp calculation displays as "NaNpp".

![image](https://user-images.githubusercontent.com/39219491/122265662-a9671280-cee1-11eb-9cd8-be88d5fbf1c2.png)
